### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ Basic python usage
     import gnt
     import pandas as pd
     lfcs = pd.read_csv('https://raw.githubusercontent.com/PeterDeWeirdt/bigpapi/master/data/processed/bigpapi_lfcs.csv')
-    guide_residuals, model_info = gnt.get_guide_residuals(lfcs, ['CD81', 'HPRT intron'], scale=True)
-    gene_scores = gnt.get_gene_residuals(guide_residuals, 'scaled_residual_z')
+    guide_residuals, model_info = gnt.get_guide_residuals(lfcs, ['CD81', 'HPRT intron'])
+    guide_residuals.sort_values('residual_z')
 
 
 TODO


### PR DESCRIPTION
I got a couple of errors when I ran the code shown in the `Basic python usage` section.

For the line#4: `guide_residuals, model_info = gnt.get_guide_residuals(lfcs, ['CD81', 'HPRT intron'], scale=True)`
```
TypeError: get_guide_residuals() got an unexpected keyword argument 'scale'
```

For the line#5: `gene_scores = gnt.get_gene_residuals(guide_residuals, 'scaled_residual_z')`
```
KeyError: "Column 'scaled_residual_z' does not exist!"
```

So, I I have replaced that code with the one from the jupyter notebook (./notebooks/basic_usage.ipynb), which did not give any errors.